### PR TITLE
Use i18next language to select date-fns locale

### DIFF
--- a/src/components/Responses.jsx
+++ b/src/components/Responses.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import formatDistance from 'date-fns/formatDistance';
-import { de } from 'date-fns/locale';
 import loadResponses from '../services/loadResponses';
+import getDateFnsLocaleObject from '../util/getDateFnsLocaleObject';
 
 const Response = ({ response }) => {
-  const date = formatDistance(new Date(response.timestamp), Date.now(), { locale: de, addSuffix: true });
+  const date = formatDistance(new Date(response.timestamp), Date.now(), { locale: getDateFnsLocaleObject(), addSuffix: true });
+
   const { t } = useTranslation();
 
   if (!response.email && !response.answer) {

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -1,7 +1,6 @@
 import { Link, useHistory } from 'react-router-dom';
 import React, { useRef, useState } from 'react';
 import formatDistance from 'date-fns/formatDistance';
-import { de } from 'date-fns/locale';
 import { useTranslation } from 'react-i18next';
 import { useAuthState } from 'react-firebase-hooks/auth';
 
@@ -10,6 +9,7 @@ import MailOutlineIcon from '@material-ui/icons/MailOutline';
 import DoneIcon from '@material-ui/icons/Done';
 
 import fb from '../../firebase';
+import getDateFnsLocaleObject from '../../util/getDateFnsLocaleObject';
 import Responses from '../Responses';
 import PopupOnEntryAction from '../Popup';
 
@@ -42,7 +42,7 @@ export default function Entry(props) {
   const [user] = useAuthState(fb.auth);
   const link = useRef(null);
 
-  const date = formatDistance(new Date(timestamp), Date.now(), { locale: de, addSuffix: true }); // @TODO get locale from i18n.language or use i18n for formatting
+  const date = formatDistance(new Date(timestamp), Date.now(), { locale: getDateFnsLocaleObject(), addSuffix: true });
   const [responsesVisible, setResponsesVisible] = useState(false);
 
   const [deleted, setDeleted] = useState(false);

--- a/src/util/getDateFnsLocaleObject.js
+++ b/src/util/getDateFnsLocaleObject.js
@@ -1,0 +1,12 @@
+import * as locales from 'date-fns/locale';
+import i18next from 'i18next';
+
+const getDateFnsLocaleObject = () => {
+  const { languages } = i18next;
+  const selectedLanguage = languages[0];
+  const fallbackLanguage = languages[languages.length-1];
+
+  return locales[selectedLanguage.replace('-', '')] || locales[fallbackLanguage.replace('-', '')];
+}
+
+export default getDateFnsLocaleObject;

--- a/src/util/getDateFnsLocaleObject.js
+++ b/src/util/getDateFnsLocaleObject.js
@@ -1,16 +1,12 @@
 import { de, enUS } from 'date-fns/locale';
 import i18next from 'i18next';
 
-const locales = { 'de': de, 'en': enUS };
+const locales = { de, en: enUS };
 
-const cutOffFromChar = (string, char) => string.indexOf(char) === -1 ? string : string.substring(0, string.indexOf(char));
-
-const getDateFnsLocaleObject = () => {
+export default function getDateFnsLocaleObject() {
   const { languages } = i18next;
   const selectedLanguage = languages[0];
-  const fallbackLanguage = languages[languages.length-1];
+  const fallbackLanguage = languages[languages.length - 1];
 
-  return locales[cutOffFromChar(selectedLanguage, '-')] || locales[cutOffFromChar(fallbackLanguage, '-')];
+  return locales[selectedLanguage.split('-')[0]] || locales[fallbackLanguage.split('-')[0]];
 }
-
-export default getDateFnsLocaleObject;

--- a/src/util/getDateFnsLocaleObject.js
+++ b/src/util/getDateFnsLocaleObject.js
@@ -1,12 +1,16 @@
-import * as locales from 'date-fns/locale';
+import { de, enUS } from 'date-fns/locale';
 import i18next from 'i18next';
+
+const locales = { 'de': de, 'en': enUS };
+
+const cutOffFromChar = (string, char) => string.indexOf(char) === -1 ? string : string.substring(0, string.indexOf(char));
 
 const getDateFnsLocaleObject = () => {
   const { languages } = i18next;
   const selectedLanguage = languages[0];
   const fallbackLanguage = languages[languages.length-1];
 
-  return locales[selectedLanguage.replace('-', '')] || locales[fallbackLanguage.replace('-', '')];
+  return locales[cutOffFromChar(selectedLanguage, '-')] || locales[cutOffFromChar(fallbackLanguage, '-')];
 }
 
 export default getDateFnsLocaleObject;


### PR DESCRIPTION
**What changes does this PR introduce**

Use the language selected through i18next for date-fns to localize time distances. Closes #276 

To see what this does exactly although currently German is force-selected as the language by i18next, you can comment out the `lng` option in `i18n.js` and set a cookie `i18next` to the desired language e.g. `en-US`, `ru`, ...