### PR TITLE
upgrade moment-timezone, remove @types/moment-timezone

### DIFF
--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -566,15 +566,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
       "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
     },
-    "@types/moment-timezone": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.13.tgz",
-      "integrity": "sha512-SWk1qM8DRssS5YR9L4eEX7WUhK/wc96aIr4nMa6p0kTk9YhGGOJjECVhIdPEj13fvJw72Xun69gScXSZ/UmcPg==",
-      "dev": true,
-      "requires": {
-        "moment": ">=2.14.0"
-      }
-    },
     "@types/node": {
       "version": "14.0.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -22,12 +22,11 @@
     "firebase-functions": "^3.3.0",
     "geofirestore": "^3.6.0",
     "googleapis": "^49.0.0",
-    "moment-timezone": "^0.5.28"
+    "moment-timezone": "^0.5.31"
   },
   "devDependencies": {
     "@types/express": "^4.17.6",
     "@types/firebase": "^3.2.1",
-    "@types/moment-timezone": "^0.5.13",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-airbnb-base": "^14.1.0",


### PR DESCRIPTION
**What changes does this PR introduce**

* Removes `@types/moment-timezone`, as they are now shipped with `moment-timezone`.
* https://github.com/moment/moment-timezone/issues/858

