### PR TITLE
Fix analytics cookie consent

### DIFF
--- a/src/components/Routes.jsx
+++ b/src/components/Routes.jsx
@@ -1,8 +1,7 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import * as Sentry from '@sentry/browser';
-import * as firebase from 'firebase';
-import 'firebase/analytics';
+import fb from '../firebase';
 
 import FilteredListFrame from '../views/FilteredListFrame';
 import OfferHelp from '../views/OfferHelp';
@@ -22,21 +21,17 @@ import CompleteNotification from '../views/CompleteNotification';
 import Main from '../views/Main';
 import NotFound from '../views/NotFound';
 import Page from './Page';
-import { CookieConsentContext } from '../util/CookieConsent';
 import HandleEmailAction from '../views/HandleEmailAction';
 import PrivacyPolicy from '../views/PrivacyPolicy';
 import Imprint from '../views/Imprint';
 import Partners from '../views/Partners';
 
 function usePageViews() {
-  const cookiesConsented = useContext(CookieConsentContext);
   const location = useLocation();
 
   useEffect(() => {
-    if (cookiesConsented) {
-      firebase.analytics().logEvent('page_view', { page_path: location.pathname });
-    }
-  }, [location, cookiesConsented]);
+    fb.analytics.logEvent('page_view', { page_path: location.pathname });
+  }, [location]);
 }
 
 export default function Routes() {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -11,10 +11,18 @@ class Firebase {
     app.initializeApp(config);
     this.app = app;
     this.auth = app.auth();
-    this.analytics = {
-      logEvent: () => {},
-    };
+    this.setAnalytics(false);
     this.store = app.firestore();
+  }
+
+  setAnalytics(state) {
+    if (state) {
+      this.analytics = app.analytics();
+      return;
+    }
+    this.analytics = {
+      logEvent: () => { },
+    };
   }
 }
 export default new Firebase();

--- a/src/util/CookieConsent.jsx
+++ b/src/util/CookieConsent.jsx
@@ -47,6 +47,11 @@ function CookieConsentBanner({ accept, reject }) {
 export default function CookieConsent({ children }) {
   const [cookiesConsented, setCookiesConsented] = useState(null);
 
+  const setCookiesConsentAndAnalytics = (state) => {
+    setCookiesConsented(state);
+    fb.setAnalytics(state);
+  };
+
   const acceptCookies = () => {
     window.localStorage.setItem('qh-cookies-accepted', 'true');
     setCookiesConsentAndAnalytics(true);
@@ -55,11 +60,6 @@ export default function CookieConsent({ children }) {
     window.localStorage.setItem('qh-cookies-accepted', 'false');
     setCookiesConsentAndAnalytics(false);
   };
-
-  const setCookiesConsentAndAnalytics = (state) => {
-    setCookiesConsented(state);
-    fb.setAnalytics(state);
-  }
 
   useEffect(() => {
     const value = window.localStorage.getItem('qh-cookies-accepted');

--- a/src/util/CookieConsent.jsx
+++ b/src/util/CookieConsent.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import fb from '../firebase';
 
 export const CookieConsentContext = React.createContext(null);
 
@@ -48,17 +49,22 @@ export default function CookieConsent({ children }) {
 
   const acceptCookies = () => {
     window.localStorage.setItem('qh-cookies-accepted', 'true');
-    setCookiesConsented(true);
+    setCookiesConsentAndAnalytics(true);
   };
   const rejectCookies = () => {
     window.localStorage.setItem('qh-cookies-accepted', 'false');
-    setCookiesConsented(false);
+    setCookiesConsentAndAnalytics(false);
   };
+
+  const setCookiesConsentAndAnalytics = (state) => {
+    setCookiesConsented(state);
+    fb.setAnalytics(state);
+  }
 
   useEffect(() => {
     const value = window.localStorage.getItem('qh-cookies-accepted');
     const isAccepted = typeof value === 'string' ? value === 'true' : null;
-    setCookiesConsented(isAccepted);
+    setCookiesConsentAndAnalytics(isAccepted);
   }, []);
 
   return (


### PR DESCRIPTION
**What changes does this PR introduce**

Analytics are currently not working, because we missed adding functionality to enable them when we refactored the cookie consent. This is fixed now fixed by initializing them once the cookie consent is given (with `setAnalytics`)
