### PR TITLE
Improved wording for PW reset and fixed layout

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -86,6 +86,7 @@
       "thisFunction": "diese Funktion",
       "whereAreYou": "Wo bist Du?",
       "whatCanWeDo": "Wobei kann man Dir helfen?",
+      "describeRequest": "Beschriebe hier, bei was Du Hilfe benötigst. Dieser Text wird potentiellen Helfenden angezeigt.",
       "requestIsPublic": "Sobald Du Deine Anfrage absendest ist diese öffentlich für andere einsehbar. Deine E-Mail-Adresse ist für andere nicht sichtbar.",
       "askNow": "Jetzt um Hilfe bitten"
     },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -169,7 +169,7 @@
       "yourPw": "Dein Passwort",
       "email": "E-Mail",
       "password": "Passwort",
-      "resetPw": "Passwort zurücksetzen",
+      "resetPw": "Passwort noch nicht gesetzt oder vergessen? – Jetzt zurücksetzen!",
       "loginNow": "Jetzt anmelden",
       "registerNow": "Neu registrieren",
       "pwResetConfirmation": "Eine E-Mail mit Anleitung zum Zurücksetzen Deines Passworts wurde Dir zugesendet!",

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -110,7 +110,7 @@ export default function AskForHelp() {
             className="border leading-tight rounded py-2 px-3 pb-20 w-full input-focus focus:outline-none"
             data-cy="ask-for-help-text-input"
             required="required"
-            placeholder={t('views.askForHelp.whatCanWeDo')}
+            placeholder={t('views.askForHelp.describeRequest')}
             onChange={(e) => setRequest(e.target.value)}
           />
         </div>

--- a/src/views/HandleEmailAction.jsx
+++ b/src/views/HandleEmailAction.jsx
@@ -288,6 +288,7 @@ function ResetPasswordView({ continueUrl, actionCode }) {
               placeholder={t('views.emailActions.resetPassword.yourPw')}
               value={password}
               required="required"
+              minLength="12"
               autoComplete="new-password"
               onChange={(e) => {
                 comparePasswords();

--- a/src/views/Signin.jsx
+++ b/src/views/Signin.jsx
@@ -90,12 +90,14 @@ export default function Signin() {
   };
 
   return (
-    <div className="p-4 mt-8">
+    <div className="p-4">
+      <div className="mt-8 mb-6">
+        <div className="font-teaser mb-6">
+          {headerText}
+        </div>
+      </div>
       <form onSubmit={signIn}>
         <div className="mb-4">
-          <div className="font-teaser mb-6">
-            {headerText}
-          </div>
           <label className="block text-gray-700 text-sm font-bold mb-1 font-open-sans" htmlFor="username">
             {t('views.signIn.email')}
           </label>
@@ -106,7 +108,7 @@ export default function Signin() {
             defaultValue={email}
           />
         </div>
-        <div className="mb-8">
+        <div className="flex flex-col items-start">
           <label className="block text-gray-700 text-sm font-bold mb-1 text font-open-sans" htmlFor="password">
             {t('views.signIn.password')}
           </label>
@@ -120,7 +122,7 @@ export default function Signin() {
             required="required"
             onChange={(e) => setPassword(e.target.value)}
           />
-          <button type="button" className="float-right text-secondary hover:underline" data-cy="btn-pw-reset" onClick={sendPasswordResetMail}>
+          <button type="button" className="self-end text-secondary hover:underline" data-cy="btn-pw-reset" onClick={sendPasswordResetMail}>
             <small>{t('views.signIn.resetPw')}</small>
           </button>
         </div>


### PR DESCRIPTION
**What changes does this PR introduce**

This PR arose from #375. However, it seems to be unfeasible what is described there. As a result, I only improved the wording for the PW reset button to signal, that users who haven't set their password yet (i.e. just enabled notification) can set a password using this button too.

This also handles the wording change of the placeholder when posting a request.

Will somewhat close #375.
Closes #381 

![Bildschirmfoto 2021-01-07 um 11 30 57](https://user-images.githubusercontent.com/20804369/103882370-fb5a6f80-50db-11eb-9c5f-34d94309d697.png)
![Bildschirmfoto 2021-01-07 um 11 31 30](https://user-images.githubusercontent.com/20804369/103882373-fd243300-50db-11eb-89cd-5d50162eb672.png)
![Bildschirmfoto 2021-01-08 um 12 47 19](https://user-images.githubusercontent.com/20804369/104012182-abe57380-51af-11eb-8525-eb865526bfac.png)