### PR TITLE
Fixing undefined email action error

### DIFF
--- a/src/util/useQuery.js
+++ b/src/util/useQuery.js
@@ -5,7 +5,7 @@ export default () => {
   const { search } = useLocation();
 
   return React.useMemo(() => {
-    const paramArray = [...new URLSearchParams(search).entries(), ...new URLSearchParams(window.location.search).entries()]
+    const paramArray = [...new URLSearchParams(search).entries(), ...new URLSearchParams(window.location.search).entries()];
     const paramObject = paramArray.reduce((obj, entry) => {
       const [key, value] = entry;
       obj[key] = value; // eslint-disable-line no-param-reassign

--- a/src/util/useQuery.js
+++ b/src/util/useQuery.js
@@ -1,19 +1,16 @@
-import { useState, useEffect } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 export default () => {
-  const [paramObject, setParamObject] = useState({});
-  const location = useLocation();
+  const { search } = useLocation();
 
-  useEffect(() => {
-    const paramArray = [...new URLSearchParams(location.search).entries(), ...new URLSearchParams(window.location.search)];
-    const newParamObject = paramArray.reduce((obj, entry) => {
+  return React.useMemo(() => {
+    const paramArray = [...new URLSearchParams(search).entries(), ...new URLSearchParams(window.location.search).entries()]
+    const paramObject = paramArray.reduce((obj, entry) => {
       const [key, value] = entry;
       obj[key] = value; // eslint-disable-line no-param-reassign
       return obj;
     }, {});
-    setParamObject(newParamObject);
-  }, [location]);
-
-  return paramObject;
+    return paramObject;
+  }, [search]);
 };


### PR DESCRIPTION
**What changes does this PR introduce**

Our currently most triggered error occurs in HandelEmailActions.jsx, whenever the mode of the firebase action is undefined. This currently happens a lot as the custom `useQuery()` hook returns an empty object at first, which makes `mode` undefined and hence leads to the error.

This fix is a rewrite of the `useQuery()` hook so that it does not return an empty object initially. The code is inspired by this https://github.com/ReactTraining/react-router/blob/085d0a862c33f9cfbbf825fddb643cbc0ed44243/packages/react-router-dom/examples/QueryParams.js#L29 and the code we already had in place