### PR TITLE
feat: add max amount of open requests per user

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ REACT_APP_ADMIN_ID=gwPMgUwQyNWMI8LpMBIaJcDvXPc2
 REACT_APP_HOTLINE_ID=r38Bl9VsfBO5Pb8D8M2IwdZKZsq1
 REACT_APP_ENV=production
 REACT_APP_DEBUG_LOGGING=false
+REACT_APP_ALLOWED_OPEN_REQUESTS_PER_USER=3
 # make sure to align the following varibles with their represententives in the firebase functions in /firebase/functions/src/config.ts
 REACT_APP_MORE_HELP_REQUEST_COOLDOWN_DAYS=1
 REACT_APP_MAXIMUM_ALLOWED_REQUESTS_FOR_HELP=3

--- a/.env.development
+++ b/.env.development
@@ -16,6 +16,7 @@ REACT_APP_ADMIN_ID=
 REACT_APP_HOTLINE_ID=
 REACT_APP_ENV=staging
 REACT_APP_DEBUG_LOGGING=true
+REACT_APP_ALLOWED_OPEN_REQUESTS_PER_USER=3
 # make sure to align the following varibles with their represententives in the firebase functions in /firebase/functions/src/config.ts
 REACT_APP_MORE_HELP_REQUEST_COOLDOWN_DAYS=1
 REACT_APP_MAXIMUM_ALLOWED_REQUESTS_FOR_HELP=3

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -90,7 +90,8 @@
       "phoneNr": "Telefonnummer",
       "autoResponseComment": "Anmerkung für automatische Antwort",
       "requestIsPublic": "Sobald Du Deine Anfrage absendest ist diese öffentlich für andere einsehbar. Deine E-Mail-Adresse ist für andere nicht sichtbar.",
-      "askNow": "Jetzt um Hilfe bitten"
+      "askNow": "Jetzt um Hilfe bitten",
+      "maximumOpenRequestsReachedExplanation": "Du hast leider die maximale Anzahl an offenen Anfragen erreicht. Bitte schließe zunächst eine Deiner offenen Anfragen in der Übersicht."
     },
     "overview": {
       "title": "Aktuelle Anfragen",

--- a/src/appConfig.jsx
+++ b/src/appConfig.jsx
@@ -3,6 +3,7 @@ const maxAllowedRequestForHelp = Number.parseInt(process.env.REACT_APP_MAXIMUM_A
 const moreHelpRequestCooldownDays = Number.parseInt(process.env.REACT_APP_MORE_HELP_REQUEST_COOLDOWN_DAYS, 10);
 const adminId = process.env.REACT_APP_ADMIN_ID;
 const hotlineId = process.env.REACT_APP_HOTLINE_ID;
+const allowedOpenRequestsPerUser = process.env.REACT_APP_ALLOWED_OPEN_REQUESTS_PER_USER;
 
 // eslint-disable-next-line import/prefer-default-export
-export { baseUrl, adminId, hotlineId, maxAllowedRequestForHelp, moreHelpRequestCooldownDays };
+export { baseUrl, adminId, hotlineId, maxAllowedRequestForHelp, moreHelpRequestCooldownDays, allowedOpenRequestsPerUser };

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { GeoFirestore } from 'geofirestore';
 import { Redirect, useHistory, Link } from 'react-router-dom';
+import { useCollectionData } from 'react-firebase-hooks/firestore';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { useTranslation } from 'react-i18next';
 import fb from '../firebase';
 import LocationInput from '../components/LocationInput';
 import { getGeodataForPlace, getLatLng } from '../services/GeoService';
 import { useEmailVerified } from '../util/emailVerified';
-import { hotlineId } from '../appConfig';
+import { hotlineId, allowedOpenRequestsPerUser } from '../appConfig';
 
 export default function AskForHelp() {
   const { t } = useTranslation();
@@ -23,6 +24,15 @@ export default function AskForHelp() {
   const history = useHistory();
 
   const isHotline = user && user.uid === hotlineId;
+
+  const askForHelpCollection = fb.store.collection('ask-for-help');
+
+  const [existingDocsForUser] = useCollectionData(
+    user ? askForHelpCollection.where('d.uid', '==', user.uid) : null,
+    { idField: 'id' },
+  );
+
+  const showAllowedRequestsHint = useMemo(() => !isHotline || (existingDocsForUser && existingDocsForUser.length > allowedOpenRequestsPerUser), [existingDocsForUser]);
 
   const handleSubmit = async (e) => {
     // Prevent page reload
@@ -81,8 +91,8 @@ export default function AskForHelp() {
     return <Redirect to="/verify-email" />;
   }
 
-  return (
-    <form onSubmit={handleSubmit} className="p-4">
+  const TopLevelContent = (() => (
+    <>
       <h1 className="font-teaser py-4 pt-10">{t('views.askForHelp.createRequest')}</h1>
       <div className="font-open-sans">
         {t('views.askForHelp.whenSomeoneWantsToHelpExplanation')}
@@ -97,6 +107,32 @@ export default function AskForHelp() {
           .
         </div>
       </div>
+    </>
+  ));
+
+  if (showAllowedRequestsHint) {
+    return (
+      <>
+        <TopLevelContent />
+        <div className="font-open-sans mt-4">
+          {t('views.askForHelp.maximumOpenRequestsReachedExplanation')}
+        </div>
+        <div className="mt-4 w-full flex justify-end">
+          <Link
+            data-cy="ask-for-help-my-overview"
+            className="btn-green w-full md:w-1/3"
+            to="/dashboard"
+          >
+            {t('components.desktopMenu.myOverview')}
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4">
+      <TopLevelContent />
       <div className="py-3">
         <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="phone">
           {t('views.askForHelp.whereAreYou')}

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -32,7 +32,7 @@ export default function AskForHelp() {
     { idField: 'id' },
   );
 
-  const showAllowedRequestsHint = useMemo(() => !isHotline || (existingDocsForUser && existingDocsForUser.length >= allowedOpenRequestsPerUser), [existingDocsForUser, isHotline]);
+  const showAllowedRequestsHint = useMemo(() => !isHotline && existingDocsForUser && existingDocsForUser.length >= allowedOpenRequestsPerUser, [existingDocsForUser, isHotline]);
 
   const handleSubmit = async (e) => {
     // Prevent page reload

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -23,7 +23,7 @@ export default function AskForHelp() {
   const [placeId, setPlaceId] = useState(undefined);
   const history = useHistory();
 
-  const isHotline = user && user.uid === hotlineId;
+  const isHotline = useMemo(() => user && user.uid === hotlineId, [user, hotlineId]);
 
   const askForHelpCollection = fb.store.collection('ask-for-help');
 
@@ -32,7 +32,7 @@ export default function AskForHelp() {
     { idField: 'id' },
   );
 
-  const showAllowedRequestsHint = useMemo(() => !isHotline || (existingDocsForUser && existingDocsForUser.length > allowedOpenRequestsPerUser), [existingDocsForUser]);
+  const showAllowedRequestsHint = useMemo(() => !isHotline || (existingDocsForUser && existingDocsForUser.length > allowedOpenRequestsPerUser), [existingDocsForUser, isHotline]);
 
   const handleSubmit = async (e) => {
     // Prevent page reload

--- a/src/views/AskForHelp.jsx
+++ b/src/views/AskForHelp.jsx
@@ -32,7 +32,7 @@ export default function AskForHelp() {
     { idField: 'id' },
   );
 
-  const showAllowedRequestsHint = useMemo(() => !isHotline || (existingDocsForUser && existingDocsForUser.length > allowedOpenRequestsPerUser), [existingDocsForUser, isHotline]);
+  const showAllowedRequestsHint = useMemo(() => !isHotline || (existingDocsForUser && existingDocsForUser.length >= allowedOpenRequestsPerUser), [existingDocsForUser, isHotline]);
 
   const handleSubmit = async (e) => {
     // Prevent page reload


### PR DESCRIPTION
**What changes does this PR introduce**

* adds a feature to limit the number of open requests a user can have to avoid potential spam.
* in this case, we show a short hint explaining to the user that they should close one of their open entries first.
* hotline account can always create new posts

## Preview

![Screenshot 2021-03-10 at 21 33 26](https://user-images.githubusercontent.com/20641332/110696612-93172f80-81eb-11eb-8627-71deaef90349.png)



