### PR TITLE
Made dropdown autocomplete scrollable

### DIFF
--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -136,7 +136,7 @@ export default function LocationInput(props) {
       <div
         id="suggestion-box"
         className="absolute w-full bg-white shadow-xl z-10 overflow-y-auto"
-        style={{ maxHeight: '300px' }}
+        style={{ maxHeight: '200px' }}
       >
         {suggestions.map((s, i) => (
           <AutocompleteSuggestion

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -133,7 +133,11 @@ export default function LocationInput(props) {
           fillLevel={inputRef.current && inputRef.current.value.length}
         />
       )}
-      <div id="suggestion-box" className="absolute w-full bg-white shadow-xl z-10">
+      <div
+        id="suggestion-box"
+        className="absolute w-full bg-white shadow-xl z-10 overflow-y-auto"
+        style={{ maxHeight: '300px' }}
+      >
         {suggestions.map((s, i) => (
           <AutocompleteSuggestion
             key={s.id}


### PR DESCRIPTION
**What changes does this PR introduce**

Richt now, if we have too many autocomplete suggestions, the box will overflow and later entries are not visible anymore. This PR limits the size of the autocomplete box and allows it to be scrollable to see all overflowing content.

Then:

https://user-images.githubusercontent.com/20804369/112139262-db165900-8bd2-11eb-9b2a-b06e091a18b3.mov

Now:

https://user-images.githubusercontent.com/20804369/112139410-0436e980-8bd3-11eb-8010-237fe5391673.mov
