### PR TITLE
feat: add loading indicator when request for more help is in progress

### DIFF
--- a/firebase/functions/src/utilities/email/sendEmailForAskForHelpEntries.ts
+++ b/firebase/functions/src/utilities/email/sendEmailForAskForHelpEntries.ts
@@ -44,7 +44,7 @@ function getTemplateDateForEntry(templateId: SendgridTemplateId, askForHelpId: s
   switch (templateId) {
     case SendgridTemplateId.TemplateForOffersWithoutAnswers:
       return {
-        subject: 'QuarantäneHeld*innen - Benötigst du weiterhin Hilfe?',
+        subject: 'QuarantäneHeld*innen - Benötigst Du weiterhin Hilfe?',
         request: askForHelpSnapData.d.request,
         location: askForHelpSnapData.d.location,
         requestMoreHelpLink: `https://www.quarantaenehelden.org/#/dashboard?entry=${askForHelpId}&moreHelp=true`,

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -215,7 +215,7 @@
       "toHome": "Bring mich zur Startseite"
     },
     "verifyEmail": {
-      "confirmEmail": "E-Mail-Addresse bestätigen",
+      "confirmEmail": "E-Mail-Adresse bestätigen",
       "explanation": "Damit potentielle Helfer*innen auf Dich zukommen können, müssen wir sicherstellen, dass Deine E-Mail-Adresse korrekt hinterlegt ist. Bestätige diese bitte, indem Du auf den Link in der E-Mail, welche wir Dir gerade gesendet haben, klickst.",
       "recheckEmail": "Bestätigung überprüfen",
       "resendEmail": "E-Mail erneut senden",
@@ -368,15 +368,15 @@
           "secondSentence": "Du kannst natürlich jederzeit eine neue Anfrage erstellen \nund eine Held*in um Hilfe bitten."
         },
         "requestMoreHelp": {
-          "heading": "Benötigst du weiterhin Hilfe?",
-          "firstSentence": "Falls du weiterhin Hilfe benötigst, werden wir für Dich neue potentielle Helfer*innen kontaktieren, die sich in Deinem Umkreis befinden.",
+          "heading": "Benötigst Du weiterhin Hilfe?",
+          "firstSentence": "Falls Du weiterhin Hilfe benötigst, werden wir für Dich neue potentielle Helfer*innen kontaktieren, die sich in Deinem Umkreis befinden.",
           "secondSentence": "Bitte beachte, dass Dir diese Funktion nur begrenzt zur Verfügung steht, um potentiellen Spam zu vermeiden.",
           "thirdSentence": "Falls Du keine Hilfe mehr benötigst, kannst Du Dein Hilfegesuch jederzeit löschen."
         },
         "requestMoreHelpSuccessful": {
           "heading": "Deine Anfrage für weitere Hilfe war erfolgreich!",
           "firstSentence": "Bitte beachte, dass es einen Augenblick dauern kann, bis sich potentieller Helfer*innen bei Dir melden.",
-          "secondSentence": "Wir hoffen, dass dir schon bald geholfen wird. Bleibe gesund!"
+          "secondSentence": "Wir hoffen, dass Dir schon bald geholfen wird. Bleibe gesund!"
         },
         "requestMoreHelpFailed": {
           "heading": "Leider ist etwas schief gelaufen...",

--- a/src/assets/loading.svg
+++ b/src/assets/loading.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin:auto;display:block;" width="80px" height="80px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+<g transform="rotate(0 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(30 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(60 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(90 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(120 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(150 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(180 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(210 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(240 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(270 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(300 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(330 50 50)">
+  <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#b6223e">
+    <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="0s" repeatCount="indefinite"></animate>
+  </rect>
+</g>
+</svg>

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -7,6 +7,7 @@ import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 
 import { ReactComponent as DotsSvg } from '../assets/dots_grey.svg';
+import { ReactComponent as LoadingSvg } from '../assets/loading.svg';
 
 import 'reactjs-popup/dist/index.css';
 
@@ -119,6 +120,7 @@ export function PopupOnEntryAction(props) {
     attemptingToRequestMoreHelp,
     cancelAttemptingToRequestMoreHelp,
     handleRequestMoreHelp,
+    requestingMoreHelp,
     moreHelpRequested,
     moreHelpRequestFailed,
     backToOverview,
@@ -263,6 +265,13 @@ export function PopupOnEntryAction(props) {
     <DeleteTerminallyButton />,
   );
 
+  const RequestMoreHelpLoading = getPopupContentComponent(
+    t('components.entry.popup.requestMoreHelp.heading'),
+    <LoadingSvg alt="loading-indicator" />,
+    null,
+    textBodyAskForMoreHelp,
+  );
+
   const RequestMoreHelpReassure = getPopupContentComponent(
     t('components.entry.popup.requestMoreHelp.heading'),
     <AskForMoreHelpButton />,
@@ -311,6 +320,7 @@ export function PopupOnEntryAction(props) {
   if (attemptingToDelete && responses !== 0 && !showAsSolved) popupContent = <PopupContentSolvedHint />;
   if (deleted) popupContent = <PopupContentDeleteSuccess />;
   if (attemptingToRequestMoreHelp) popupContent = <RequestMoreHelpReassure />;
+  if (requestingMoreHelp) popupContent = <RequestMoreHelpLoading />;
   if (moreHelpRequested) popupContent = <RequestMoreHelpSuccess />;
   if (moreHelpRequestFailed) popupContent = <RequestMoreHelpFailed />;
 

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -119,6 +119,7 @@ export default function Entry(props) {
       setRequestingMoreHelp(false);
       setMoreHelpRequested(true);
     } catch (err) {
+      setRequestingMoreHelp(false);
       setMoreHelpRequestFailed(true);
     }
     fb.analytics.logEvent('more_help_requested');

--- a/src/components/entry/Entry.jsx
+++ b/src/components/entry/Entry.jsx
@@ -58,6 +58,7 @@ export default function Entry(props) {
   const [solved, setSolved] = useState(false);
   const [moreHelpRequested, setMoreHelpRequested] = useState(false);
   const [moreHelpRequestFailed, setMoreHelpRequestFailed] = useState(false);
+  const [requestingMoreHelp, setRequestingMoreHelp] = useState(false);
   const [attemptingToDelete, setAttemptingToDelete] = useState(showDeleteHint);
   const [attemptingToSolve, setAttemptingToSolve] = useState(showSolveHint);
   const [attemptingToReport, setAttemptingToReport] = useState(report);
@@ -113,7 +114,9 @@ export default function Entry(props) {
   const handleRequestMoreHelp = async (e) => {
     e.preventDefault();
     try {
+      setRequestingMoreHelp(true);
       await fb.askForMoreHelp(id);
+      setRequestingMoreHelp(false);
       setMoreHelpRequested(true);
     } catch (err) {
       setMoreHelpRequestFailed(true);
@@ -235,6 +238,7 @@ export default function Entry(props) {
       attemptingToRequestMoreHelp={attemptingToRequestMoreHelp}
       cancelAttemptingToRequestMoreHelp={cancelAttemptingToRequestMoreHelp}
       handleRequestMoreHelp={handleRequestMoreHelp}
+      requestingMoreHelp={requestingMoreHelp}
       moreHelpRequested={moreHelpRequested}
       moreHelpRequestFailed={moreHelpRequestFailed}
       backToOverview={backToOverview}


### PR DESCRIPTION
**What changes does this PR introduce**

This PR adds a loading indicator when a user hits the button to request more help for the time the request is in progress. With this, the user is unable to spam the button if the request takes longer, e.g, on a cold start of the function.


https://user-images.githubusercontent.com/20641332/112736325-2ec9cf00-8f52-11eb-8ba8-e9cd45f662ce.mov


https://user-images.githubusercontent.com/20641332/112736322-2bcede80-8f52-11eb-8dd2-043e2e185a87.mov


