### PR TITLE
Fix/carry over selected location from landing page to notify-me component

### DIFF
--- a/src/components/EntryList.jsx
+++ b/src/components/EntryList.jsx
@@ -158,7 +158,7 @@ export default function EntryList({ pageSize }) {
           />
         </div>
       ) : null}
-      <NotifyMe location={location} />
+      <NotifyMe location={location} placeId={placeId} />
       {entries.length === 0 ? (
         <div className="w-full text-center my-10 font-open-sans">
           {t('components.filteredList.noHelpCurrentlyNeededIn', {

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -109,7 +109,7 @@ export default function LocationInput(props) {
     if (!isInitiallyValid) {
       setInvalidNoSelect();
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadingVisible = (value.length < minSearchInput) || waitingForResults;
 

--- a/src/components/LocationInput.jsx
+++ b/src/components/LocationInput.jsx
@@ -13,6 +13,7 @@ export default function LocationInput(props) {
     debounce = 200,
     minSearchInput = 4,
     onSelect = () => { },
+    isInitiallyValid = false,
   } = props;
 
   const { t } = useTranslation();
@@ -104,7 +105,11 @@ export default function LocationInput(props) {
     }
   };
 
-  useEffect(setInvalidNoSelect, []);
+  useEffect(() => {
+    if (!isInitiallyValid) {
+      setInvalidNoSelect();
+    }
+  }, []);
 
   const loadingVisible = (value.length < minSearchInput) || waitingForResults;
 

--- a/src/components/NotifyMe.jsx
+++ b/src/components/NotifyMe.jsx
@@ -3,18 +3,18 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import fb from '../firebase';
 
-export default function NotifyMe({ location }) {
+export default function NotifyMe({ location, placeId }) {
   const { t } = useTranslation();
 
   return (
     <div className="py-3 w-full">
       <div className="my-3 w-full">
         <Link
-          to="/notify-me"
+          to={location && placeId ? `/notify-me?location=${location}&placeId=${placeId}` : '/notify-me'}
           className="btn-green-secondary my-3 w-full block"
           onClick={() => fb.analytics.logEvent('button_subscribe_region')}
         >
-          {location && location !== ''
+          {location && placeId
             ? t('components.filteredList.notifyMeForLocation', { location })
             : t('components.filteredList.notifyMeFallback')}
         </Link>

--- a/src/views/NotifyMe.jsx
+++ b/src/views/NotifyMe.jsx
@@ -51,6 +51,7 @@ export default function NotifyMe() {
     setPlaceId(pId);
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => history.replace(windowLocation.pathname), []);
 
   if (signInLinkSent) {

--- a/src/views/NotifyMe.jsx
+++ b/src/views/NotifyMe.jsx
@@ -1,22 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuthState } from 'react-firebase-hooks/auth';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useHistory } from 'react-router-dom';
 import * as Sentry from '@sentry/browser';
 import fb from '../firebase';
 import LocationInput from '../components/LocationInput';
 import MailInput from '../components/MailInput';
 import { baseUrl } from '../appConfig';
+import useQuery from '../util/useQuery';
 import HelpNeededLogo from '../assets/help_needed.svg';
 
 export default function NotifyMe() {
   const { t } = useTranslation();
   const [user] = useAuthState(fb.auth);
 
+  const { location: queryLocation, placeId: queryPid } = useQuery();
+
   const [email, setEmail] = useState((user && user.email) || '');
   const [signInLinkSent, setSignInLinkSent] = useState(false);
-  const [location, setLocation] = useState('');
-  const [placeId, setPlaceId] = useState('');
+  const [location, setLocation] = useState(queryLocation || '');
+  const [placeId, setPlaceId] = useState(queryPid || '');
+  const history = useHistory();
+  const windowLocation = useLocation();
 
   const handleSubmit = async (e) => {
     // Prevent page reload
@@ -46,6 +51,8 @@ export default function NotifyMe() {
     setPlaceId(pId);
   };
 
+  useEffect(() => history.replace(windowLocation.pathname), []);
+
   if (signInLinkSent) {
     return (
       <div className="p-4">
@@ -73,7 +80,7 @@ export default function NotifyMe() {
         {t('views.notifyMe.beNotified')}
       </div>
       <form onSubmit={handleSubmit}>
-        <LocationInput required onChange={handleChange} value={location} onSelect={handleSelect} />
+        <LocationInput required onChange={handleChange} value={location} onSelect={handleSelect} isInitiallyValid={!!placeId} />
         <MailInput className="input-focus my-6" placeholder={t('views.notifyMe.yourMail')} onChange={setEmail} defaultValue={email} />
         <button className="mt-6 btn-green w-full disabled:opacity-75 disabled:cursor-not-allowed" type="submit">
           {t(


### PR DESCRIPTION
**What changes does this PR introduce**

* This PR adds functionality to carry over the selected postal code from the landing page to the notify me component, removing the necessity for the user to enter the location postal code again :)

https://user-images.githubusercontent.com/20641332/112738074-f03b1100-8f5f-11eb-9d47-c4786703f656.mov


